### PR TITLE
Add repeat (Eder Lomba of Rainmain 9b)

### DIFF
--- a/data/lead.json
+++ b/data/lead.json
@@ -211,9 +211,12 @@
 		"name": "Rainman",
 		"grade": "9b",
 		"fa": "Steve McClure",
-		"repeat": [],
+		"repeat": [
+			"Eder Lomba"
+		],
 		"videos": {
-			"McClure": "https://youtu.be/L01OUNJvd1E"
+			"McClure": "https://youtu.be/L01OUNJvd1E",
+			"Lomba": "https://youtu.be/tAeVbsv0mgc"
 		}
 	},
 	{


### PR DESCRIPTION
Eder Lomba makes second ascent of Rainman (9b)
source: https://www.ukclimbing.com/news/2022/05/eder_lomba_makes_second_ascent_of_rainman_9b-73054
source: https://www.instagram.com/p/CdnEuVmD5Ec/