### PR TITLE
Added 2 videos, fixed FA

### DIFF
--- a/data/lead.json
+++ b/data/lead.json
@@ -57,7 +57,8 @@
         "repeat": ["Stefano Ghisolfi", "Sean Bailey"],
         "videos": {
             "Megos": "https://youtu.be/COuxNFuAS1Q",
-            "Ghisolfi": "https://youtu.be/UJnTmYiMBeI"
+            "Ghisolfi": "https://youtu.be/UJnTmYiMBeI",
+            "Bailey": "https://youtu.be/OneTmfEsANI?t=1737"
         }
     },
     {

--- a/data/lead.json
+++ b/data/lead.json
@@ -254,7 +254,7 @@
 		"fa": "Sebastien Bouin",
 		"repeat": [],
 		"videos": {
-			"": ""
+			"Bouin": "https://youtu.be/D-pWmpZp7VQ?t=430"
 		}
 	},
 	{

--- a/data/lead.json
+++ b/data/lead.json
@@ -223,8 +223,8 @@
 	{
 		"name": "Stoking the Fire",
 		"grade": "9b",
-		"fa": "Adam Ondra",
-		"repeat": ["Stefano Ghisolfi", "Sachi Amma"],
+		"fa": "Chris Sharma",
+		"repeat": ["Adam Ondra", "Stefano Ghisolfi", "Sachi Amma"],
 		"videos": {
 			"Ondra": "https://youtu.be/Uo64D1-Vumw",
 			"Amma": "https://youtu.be/FRZVA090NZ4"


### PR DESCRIPTION
Adding 2 videos, both are longer ones with lots of stuff so the link is to the timestamp with the route.
Fixed FA ([source](https://www.ukclimbing.com/news/2013/02/stoking_the_fire_-_another_9b_from_sharma-67799))